### PR TITLE
feat: implementing ignore content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ dist
 .tern-port
 
 package-lock.json
+.DS_Store

--- a/__mock/heimdallrc/heimdallrc.json
+++ b/__mock/heimdallrc/heimdallrc.json
@@ -7,6 +7,9 @@
       "ext": ["c"]
     }
   ],
+  "ignore-content": [
+    "\\\".*\\\"|'.*'"
+  ],
   "ext": ["h", "c", "cpp"],
   "exclude": [".git"]
 }

--- a/src/commands/cli-command-handler.js
+++ b/src/commands/cli-command-handler.js
@@ -22,6 +22,7 @@ class CliCommandHandler extends AbstractCommandHandler {
    * @return { AbstractHandler }
    */
   handle(command) {
+    const errorDetector = { hasError: false }
     const options = command.opts()
     const path = options.path || process.cwd()
 
@@ -31,7 +32,11 @@ class CliCommandHandler extends AbstractCommandHandler {
 
     this._validateHeimdallrcContent(heimdallrcContent)
 
-    discoverAndPrintErrors(path, heimdallrcContent, options)
+    discoverAndPrintErrors(path, heimdallrcContent, options, errorDetector)
+
+    if (errorDetector.hasError) {
+      process.exit(1)
+    }
 
     return super.handle(command)
   }

--- a/src/helpers/check-rules.js
+++ b/src/helpers/check-rules.js
@@ -68,8 +68,6 @@ function printErrors(error) {
 
     console.log('')
   })
-
-  if (error.hasError) process.exit(1)
 }
 
 /**

--- a/src/helpers/check-rules.js
+++ b/src/helpers/check-rules.js
@@ -88,7 +88,7 @@ function addHighlights(regex, text) {
  * Check with the line does match with some rule and returns this rule
  * @param { Array<string> } rules - The array of rules
  * @param { string } lineContent - The content of line
- * @returns { RegExp | null }
+ * @returns { RegExp | undefined }
  */
 function getMatchedRule(rules, lineContent) {
   for (let rule of rules) {
@@ -96,8 +96,6 @@ function getMatchedRule(rules, lineContent) {
 
     if (regex.test(lineContent)) return regex
   }
-
-  return null
 }
 
 /**

--- a/src/helpers/check-rules.js
+++ b/src/helpers/check-rules.js
@@ -105,11 +105,9 @@ function getMatchedRule(rules, lineContent) {
  * @returns { string }
  */
 function blinderContent(lineContent, ignoreContent) {
-  const blinder = Date.now()
-
   return (ignoreContent || [])
     .reduce((line, replacer) => {
-      return line.replace(replacer, `"${blinder}"`)
+      return line.replace(replacer, 'Ø') // the character Ø is just to avoid macthes with other rules
     }, lineContent)
 }
 

--- a/src/helpers/discover-files.js
+++ b/src/helpers/discover-files.js
@@ -27,7 +27,7 @@ function discoverAndPrintErrors(path, heimdallrc, options) {
 
       if (isAllowedExtension) {
         const fileContent = loadFile(fullPath)
-        const errors = checkRules({ fullPath, extension }, fileContent, heimdallrc.rules)
+        const errors = checkRules({ fullPath, extension }, fileContent, heimdallrc)
 
         printErrors(errors)
       }

--- a/src/helpers/discover-files.js
+++ b/src/helpers/discover-files.js
@@ -7,8 +7,9 @@ const { listDir, loadFile } = require('./disk-manager')
  * @param { string } path - Tha base dir path
  * @param { Heimdallrc } heimdallrc - The heimdallrc content
  * @param { import('commander').OptionValues } options - The command options
+ * @param { ErrorDetector } errorDetector - Informs that erros are found
  */
-function discoverAndPrintErrors(path, heimdallrc, options) {
+function discoverAndPrintErrors(path, heimdallrc, options, errorDetector) {
   const list = listDir(path)
 
   for (let item of list) {
@@ -20,7 +21,7 @@ function discoverAndPrintErrors(path, heimdallrc, options) {
 
     if (item.isDirectory()) {
       // find new files into directory
-      discoverAndPrintErrors(fullPath, heimdallrc, options)
+      discoverAndPrintErrors(fullPath, heimdallrc, options, errorDetector)
     } else {
       const extension = item.name.split('.').pop()
       const isAllowedExtension = heimdallrc.ext.includes(extension)
@@ -30,6 +31,10 @@ function discoverAndPrintErrors(path, heimdallrc, options) {
         const errors = checkRules({ fullPath, extension }, fileContent, heimdallrc)
 
         printErrors(errors)
+
+        if (errors.hasError) {
+          errorDetector.hasError = true
+        }
       }
     }
   }

--- a/src/helpers/heimdallrc-setting-file.js
+++ b/src/helpers/heimdallrc-setting-file.js
@@ -43,17 +43,17 @@ function exists(currentPath) {
  */
 function getHeimdallrcContent(currentPath) {
   const fullPath = path.join(currentPath, 'heimdallrc.json')
-  const heimdallrcContent = jsonParse(loadFile(fullPath).join(''))
+  const content = jsonParse(loadFile(fullPath).join(''))
 
-  if (heimdallrcContent.exclude) {
-    heimdallrcContent.exclude = heimdallrcContent.exclude.map(r => new RegExp(r))
+  if (content.exclude) {
+    content.exclude = content.exclude.map(r => new RegExp(r))
   }
 
-  if (heimdallrcContent['ignore-content']) {
-    heimdallrcContent['ignore-content'] = heimdallrcContent['ignore-content'].map(r => new RegExp(r, 'g'))
+  if (content['ignore-content']) {
+    content['ignore-content'] = content['ignore-content'].map(r => new RegExp(r, 'g'))
   }
 
-  return heimdallrcContent.rules ? heimdallrcContent : undefined
+  return content.rules ? content : undefined
 }
 
 /**

--- a/src/helpers/heimdallrc-setting-file.js
+++ b/src/helpers/heimdallrc-setting-file.js
@@ -49,6 +49,10 @@ function getHeimdallrcContent(currentPath) {
     heimdallrcContent.exclude = heimdallrcContent.exclude.map(r => new RegExp(r))
   }
 
+  if (heimdallrcContent['ignore-content']) {
+    heimdallrcContent['ignore-content'] = heimdallrcContent['ignore-content'].map(r => new RegExp(r, 'g'))
+  }
+
   return heimdallrcContent.rules ? heimdallrcContent : undefined
 }
 

--- a/src/schemes/heimdallrc-schema.json
+++ b/src/schemes/heimdallrc-schema.json
@@ -44,6 +44,12 @@
         "minLength": 1
       }
     },
+    "ignore-content": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
     "exclude": {
       "type": "array",
       "minItems": 1,

--- a/src/types/typedef.js
+++ b/src/types/typedef.js
@@ -44,3 +44,8 @@
  * @property { string } fullPath
  * @property { string } extension
  */
+
+/**
+ * @typedef ErrorDetector
+ * @property { boolean } hasError
+ */

--- a/src/types/typedef.js
+++ b/src/types/typedef.js
@@ -1,6 +1,7 @@
 /**
  * @typedef Heimdallrc
  * @property { Array<string> } ext
+ * @property { Array<RegExp> } `ignore-content`
  * @property { Array<RegExp> } exclude
  * @property { Array<Rule> } rules
  */


### PR DESCRIPTION
#### Solution
In some cases we considering the content inside of strings ("...", '...'), but the rules does't should match into strings.
To solve it, I added an attribute dedicated to ignore this contents.

This attribute is named by `ignore-content` and his content is an array of Regular Expression that be used to ignore the matches for each line content. It can be used to ignore other patterns instead only strings too.
